### PR TITLE
fix(systemd): resolve invalid environment syntax in shorekeeper-daemon.service

### DIFF
--- a/deploy/systemd/shorekeeper-daemon.service
+++ b/deploy/systemd/shorekeeper-daemon.service
@@ -7,7 +7,8 @@ Type=simple
 User=ubuntu
 WorkingDirectory=/home/ubuntu/projects/shorekeeper
 Environment="PATH=/home/ubuntu/.local/bin:/usr/local/bin:/usr/bin:/bin"
-Environment="OMP_BRIDGE_MOCK=0"        # Production mode: real Hermes WS executor
+# Production mode: real Hermes WS executor
+Environment="OMP_BRIDGE_MOCK=0"
 Environment="HERMES_WS_URL=ws://127.0.0.1:9119/api/ws"
 Environment="HERMES_WS_TOKEN=jarvis-voice-secret-2026"
 Environment="SHOREKEEPER_DB=/home/ubuntu/projects/shorekeeper/data/tasks.db"


### PR DESCRIPTION
### Summary
Fixes invalid environment assignment syntax in `shorekeeper-daemon.service` where inline comments on `Environment=` directives caused systemd parse warnings.

- Moved inline `#` comment to a separate line above the directive in `deploy/systemd/shorekeeper-daemon.service`.
- Cleaned and updated live system unit `/etc/systemd/system/shorekeeper-daemon.service` and performed `systemctl daemon-reload` with 0 warnings.

Closes #9