### PR TITLE
perf(agent): eliminate voice room cold start via prewarmed process pool

### DIFF
--- a/apps/agent/src/agent_gemini_live.py
+++ b/apps/agent/src/agent_gemini_live.py
@@ -147,7 +147,8 @@ SHOREKEEPER_INSTRUCTIONS = textwrap.dedent(
 )
 
 server = AgentServer(
-    num_idle_processes=0,
+    # Eliminate 5.28s cold start while respecting VPS 3.6GB RAM guard (Issue #8)
+    num_idle_processes=int(os.getenv("SHOREKEEPER_NUM_IDLE_PROCESSES", "1")),
     job_memory_limit_mb=600,
     load_threshold=0.95,
     multiprocessing_context="spawn",


### PR DESCRIPTION
Closes #8

### Summary of Changes
- Configure `AgentServer(num_idle_processes=int(os.getenv("SHOREKEEPER_NUM_IDLE_PROCESSES", "1")))` in `apps/agent/src/agent_gemini_live.py`.
- Keeps a hot idle process ready for incoming LiveKit voice sessions, eliminating the 5.28s cold start observed in `AJ_nvg2Fto9WHDX` and `AJ_QjWiWBwbjb8x`.
- Preserves memory safety guards within VPS 3.6GB RAM constraints (`job_memory_limit_mb=600`, systemd cgroup 800M).

### Verification
- `uv run --project apps/agent ruff check .` passed.
- `uv run --project apps/agent pytest -q apps/agent/tests` passed (24/24 passed).