### PR TITLE
fix(agent): standardize Gemini API keys and mitigate AFC warning

### DIFF
--- a/apps/agent/src/agent_gemini_live.py
+++ b/apps/agent/src/agent_gemini_live.py
@@ -28,8 +28,20 @@ from livekit.plugins.google.realtime import RealtimeModel
 
 logger = logging.getLogger("shorekeeper-agent")
 
+# Suppress spurious SDK internal warnings from google_genai:
+# 1. Dual API key collision (GOOGLE_API_KEY vs GEMINI_API_KEY)
+# 2. Direct AFC warning in AsyncModels.generate_content_stream (used internally by LiveKit GeminiTTS)
+logging.getLogger("google_genai._api_client").setLevel(logging.ERROR)
+logging.getLogger("google_genai.models").setLevel(logging.ERROR)
+
 load_dotenv(".env.local")
 load_dotenv(".env")
+
+# Canonicalize Google/Gemini API key in os.environ to avoid downstream SDK collision warnings (Issue #10)
+_canonical_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+if _canonical_key:
+    os.environ["GEMINI_API_KEY"] = _canonical_key
+    os.environ["GOOGLE_API_KEY"] = _canonical_key
 
 # Database Path
 DATA_DIR = os.getenv("SHOREKEEPER_DATA_DIR") or os.path.abspath(


### PR DESCRIPTION
Closes #10

### Summary of Changes
- Canonicalize `GEMINI_API_KEY` and `GOOGLE_API_KEY` in `apps/agent/src/agent_gemini_live.py`.
- Set log level of internal `google_genai._api_client` and `google_genai.models` to `ERROR` to suppress SDK advisory warnings on LiveKit TTS automatic function call streaming and redundant key detection.

### Verification
- `uv run --project apps/agent ruff check .` passed.
- `uv run --project apps/agent pytest -q apps/agent/tests` passed (24/24 passed).