### PR TITLE
fix(client): enforce 48kHz audio capture constraints on microphone track

### DIFF
--- a/apps/client/src/lib/livekit-voice.ts
+++ b/apps/client/src/lib/livekit-voice.ts
@@ -149,9 +149,15 @@ export async function startLivekitVoice(opts: LivekitVoiceOptions): Promise<Live
     // Autoplay unlock — we are inside the orb-tap gesture.
     await room.startAudio();
 
-    // Mic on: WebRTC capture replaces the old getUserMedia pipeline.
+    // Mic on: WebRTC capture with standard audio constraints (echoCancellation, noiseSuppression, sampleRate 48kHz)
     const local = room.localParticipant as LocalParticipant;
-    await local.setMicrophoneEnabled(true);
+    await local.setMicrophoneEnabled(true, {
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+      sampleRate: 48000,
+      channelCount: 1,
+    });
     opts.onLog('Microphone enabled');
 
     // Connect user mic MediaStream to AudioAnalyser for 3D Spectro Particle Visualizer


### PR DESCRIPTION
Closes #11

### Summary of Changes
- Specify explicit audio constraints on `local.setMicrophoneEnabled(true, { ... })`:
  - `sampleRate: 48000`
  - `channelCount: 1`
  - `echoCancellation: true`, `noiseSuppression: true`, `autoGainControl: true`
- Aligns WebRTC audio frame packet size with LiveKit agent's internal audio pipeline to mitigate `Input is shorter by 168 samples` alignment warnings.

### Verification
- `pnpm -C apps/client lint` passed.
- `pnpm -C apps/client test` passed (19 passed, 5 skipped).