### PR TITLE
fix(mempalace): implement JSON-RPC tools/call client connector for MemPalace L2

### DIFF
--- a/apps/agent/src/agent_gemini_live.py
+++ b/apps/agent/src/agent_gemini_live.py
@@ -26,6 +26,8 @@ from livekit.agents import (
 )
 from livekit.plugins.google.realtime import RealtimeModel
 
+from mempalace_client import search_mempalace_mcp
+
 logger = logging.getLogger("shorekeeper-agent")
 
 # Suppress spurious SDK internal warnings from google_genai:
@@ -182,52 +184,14 @@ VALID_GEMINI_VOICES = {
 
 
 async def search_mempalace(query: str, timeout: float = 1.5) -> str:
-    """Core logic Sprint A.3: query MemPalace MCP HTTP, return top-k ringkas.
+    """Core logic Sprint A.3: query MemPalace MCP HTTP (JSON-RPC 2.0 tools/call), return top-k ringkas.
 
     Timeout default 1.5s. Jika down → return narasi natural (BUKAN error mentah).
     Dipisah dari @function_tool agar bisa di-unit-test tanpa LiveKit tool machinery.
     """
     logger.info(f"Searching MemPalace: {query}")
-    try:
-        # Get MCP endpoint from environment (set by user/config)
-        mcp_endpoint = os.getenv("MEMPALACE_MCP_HTTP_ENDPOINT", "")
-        mcp_token = os.getenv("MEMPALACE_MCP_HTTP_TOKEN", "")
-
-        if not mcp_endpoint or not mcp_token:
-            return "Aku sedang kesulitan mengakses memori jangka panjangku — konfigurasi MCP belum tersedia."
-
-        async with aiohttp.ClientSession() as session:
-            url = f"{mcp_endpoint}/search"
-            headers = {"Authorization": f"Bearer {mcp_token}"}
-            params = {"query": query, "limit": 3}
-
-            async with session.get(
-                url,
-                headers=headers,
-                params=params,
-                timeout=aiohttp.ClientTimeout(total=timeout),
-            ) as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    results = data.get("results", [])
-                    if not results:
-                        return f"Tidak ditemukan ingatan terkait '{query}' dalam memoriku."
-
-                    items = []
-                    for r in results[:3]:
-                        title = r.get("title", "tanpa judul")
-                        preview = r.get("content", "")[:150]
-                        wing = r.get("wing", "unknown")
-                        items.append(f"- {title} ({wing}): {preview}...")
-
-                    return f"Hasil pencarian ingatan untuk '{query}':\n" + "\n".join(items)
-                return "Aku sedang kesulitan mengakses ingatanku, coba lagi sebentar lagi."
-    except asyncio.TimeoutError:
-        logger.warning(f"MemPalace search timeout: {query}")
-        return "Aku sedang kesulitan mengakses ingatanku, coba lagi sebentar lagi."
-    except Exception as e:
-        logger.warning(f"MemPalace search failed: {e}")
-        return "Aku sedang kesulitan mengakses ingatanku, coba lagi sebentar lagi."
+    res = await search_mempalace_mcp(query=query, limit=3, timeout=timeout)
+    return res.get("narrative", f"Tidak ditemukan ingatan terkait '{query}' dalam memoriku.")
 
 
 class ShorekeeperAgent(Agent):
@@ -376,33 +340,12 @@ class ShorekeeperAgent(Agent):
 async def build_session_context(room_name: str) -> str:
     parts: list[str] = []
 
-    # 1. MemPalace preferences + active projects
-    mcp_endpoint = os.getenv("MEMPALACE_MCP_HTTP_ENDPOINT", "")
-    mcp_token = os.getenv("MEMPALACE_MCP_HTTP_TOKEN", "")
-    if mcp_endpoint and mcp_token:
-        try:
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Bearer {mcp_token}"}
-                for query, label in [
-                    ("preferensi user", "Preferensi"),
-                    ("proyek aktif", "Proyek Aktif"),
-                ]:
-                    async with session.get(
-                        f"{mcp_endpoint}/search",
-                        headers=headers,
-                        params={"query": query, "limit": 2},
-                        timeout=aiohttp.ClientTimeout(total=1.5),
-                    ) as resp:
-                        if resp.status == 200:
-                            data = await resp.json()
-                            results = data.get("results", [])[:2]
-                            if results:
-                                lines = [r.get("content", "")[:120] for r in results]
-                                parts.append(f"{label}: {' | '.join(lines)}")
-        except Exception as e:
-            logger.warning(f"MemPalace context fetch failed: {e}")
-    else:
-        logger.warning("MemPalace MCP endpoint/token not set — skipping context injection")
+    # 1. MemPalace preferences + active projects via JSON-RPC 2.0
+    for q, label in [("preferensi user", "Preferensi"), ("proyek aktif", "Proyek Aktif")]:
+        res = await search_mempalace_mcp(query=q, limit=2, timeout=1.5)
+        if res.get("status") == "ok" and res.get("drawers"):
+            lines = [d.get("snippet", "") for d in res.get("drawers", [])]
+            parts.append(f"{label}: {' | '.join(lines)}")
 
     # 2. SQLite: 5 task terakhir
     try:

--- a/apps/agent/src/mempalace_client.py
+++ b/apps/agent/src/mempalace_client.py
@@ -1,0 +1,204 @@
+"""MemPalace L2 MCP HTTP Client Connector.
+
+Provides robust async querying to MemPalace L2 via MCP JSON-RPC 2.0 over HTTP.
+Designed for voice agents (low latency, fail-open graceful fallbacks).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_mcp_url(endpoint: str) -> str:
+    """Normalize endpoint to point to /mcp path."""
+    url = endpoint.strip().rstrip("/")
+    if not url.endswith("/mcp"):
+        url = f"{url}/mcp"
+    return url
+
+
+async def search_mempalace_mcp(
+    query: str,
+    limit: int = 3,
+    wing: str | None = None,
+    room: str | None = None,
+    timeout: float = 1.5,
+    endpoint: str | None = None,
+    token: str | None = None,
+) -> dict[str, Any]:
+    """Search MemPalace L2 using MCP JSON-RPC 2.0 protocol over HTTP.
+
+    Returns a dict with:
+        - status: "ok" | "empty" | "error" | "timeout" | "fail_open" | "unconfigured"
+        - narrative: Human-friendly Indonesian text suitable for voice output
+        - drawers: List of parsed drawer dicts (wing, room, source_file, similarity, text, snippet)
+        - latency_ms: Execution time in milliseconds
+        - raw: Raw decoded results (if available)
+
+    Fails open gracefully: returns polite natural narrative on timeout or error,
+    never crashing or leaking raw stack traces.
+    """
+    mcp_endpoint = endpoint or os.getenv("MEMPALACE_MCP_HTTP_ENDPOINT", "")
+    mcp_token = token or os.getenv("MEMPALACE_MCP_HTTP_TOKEN", "")
+
+    if not mcp_endpoint or not mcp_token:
+        return {
+            "status": "unconfigured",
+            "narrative": "Aku sedang kesulitan mengakses memori jangka panjangku — konfigurasi MCP belum tersedia.",
+            "drawers": [],
+            "latency_ms": 0.0,
+        }
+
+    url = _normalize_mcp_url(mcp_endpoint)
+    req_id = int(time.time() * 1000) % 1000000
+
+    arguments: dict[str, Any] = {
+        "query": query,
+        "limit": limit,
+    }
+    if wing:
+        arguments["wing"] = wing
+    if room:
+        arguments["room"] = room
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": "tools/call",
+        "params": {
+            "name": "mempalace_search",
+            "arguments": arguments,
+        },
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {mcp_token}",
+    }
+
+    t0 = time.perf_counter()
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp,
+        ):
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+
+            if resp.status != 200:
+                logger.warning("MemPalace HTTP status %s: %s", resp.status, await resp.text())
+                return {
+                    "status": "fail_open",
+                    "http_code": resp.status,
+                    "latency_ms": elapsed_ms,
+                    "narrative": "Aku sedang kesulitan mengakses ingatanku, coba lagi sebentar lagi.",
+                    "drawers": [],
+                }
+
+            data = await resp.json()
+            if "error" in data:
+                err_info = data.get("error", {})
+                logger.warning("MemPalace JSON-RPC error: %s", err_info)
+                return {
+                    "status": "error",
+                    "error": err_info,
+                    "latency_ms": elapsed_ms,
+                    "narrative": "Aku sedang kesulitan mengakses ingatanku, coba lagi sebentar lagi.",
+                    "drawers": [],
+                }
+
+            # Parse MCP response envelope: result.content[0].text is a JSON string
+            content_items = data.get("result", {}).get("content", [])
+            raw_text = content_items[0].get("text", "{}") if content_items else "{}"
+
+            try:
+                search_data = json.loads(raw_text)
+            except Exception as parse_err:
+                logger.warning("Failed to parse inner MCP JSON text: %s", parse_err)
+                return {
+                    "status": "error",
+                    "error": str(parse_err),
+                    "latency_ms": elapsed_ms,
+                    "narrative": "Aku sedang kesulitan mengakses ingatanku, coba lagi sebentar lagi.",
+                    "drawers": [],
+                }
+
+            results = search_data.get("results", [])
+            if not results:
+                return {
+                    "status": "empty",
+                    "latency_ms": elapsed_ms,
+                    "narrative": f"Tidak ditemukan ingatan terkait '{query}' dalam memoriku.",
+                    "drawers": [],
+                }
+
+            drawers = []
+            narrative_items = []
+            for r in results[:limit]:
+                text = r.get("text", "")
+                wing_name = r.get("wing", "unknown")
+                room_name = r.get("room", "unknown")
+                source_file = r.get("source_file", "?")
+                similarity = r.get("similarity", 0.0)
+
+                # Clean preview snippet
+                snippet = text.strip()
+                if len(snippet) > 150:
+                    snippet = snippet[:150] + "..."
+
+                drawers.append({
+                    "wing": wing_name,
+                    "room": room_name,
+                    "source_file": source_file,
+                    "similarity": similarity,
+                    "text": text,
+                    "snippet": snippet,
+                })
+
+                narrative_items.append(f"- ({wing_name}/{room_name}): {snippet}")
+
+            narrative = (
+                f"Hasil pencarian ingatan untuk '{query}':\n"
+                + "\n".join(narrative_items)
+            )
+
+            return {
+                "status": "ok",
+                "latency_ms": elapsed_ms,
+                "narrative": narrative,
+                "drawers": drawers,
+                "raw": search_data,
+            }
+
+    except asyncio.TimeoutError:
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        logger.warning("MemPalace search timeout after %.1fms: %s", elapsed_ms, query)
+        return {
+            "status": "timeout",
+            "latency_ms": elapsed_ms,
+            "narrative": "Aku sedang kesulitan mengakses ingatanku, coba lagi sebentar lagi.",
+            "drawers": [],
+        }
+    except Exception as exc:
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        logger.warning("MemPalace search exception after %.1fms: %s", elapsed_ms, exc)
+        return {
+            "status": "exception",
+            "error": str(exc),
+            "latency_ms": elapsed_ms,
+            "narrative": "Aku sedang kesulitan mengakses ingatanku, coba lagi sebentar lagi.",
+            "drawers": [],
+        }

--- a/apps/agent/tests/test_mempalace_client.py
+++ b/apps/agent/tests/test_mempalace_client.py
@@ -1,0 +1,142 @@
+"""Unit and live integration tests for mempalace_client.py."""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+
+from mempalace_client import _normalize_mcp_url, search_mempalace_mcp
+
+
+class FakeResponse:
+    def __init__(self, status: int, json_data: dict, text_data: str = ""):
+        self.status = status
+        self._json_data = json_data
+        self._text_data = text_data
+
+    async def json(self):
+        return self._json_data
+
+    async def text(self):
+        return self._text_data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class FakeSession:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def post(self, url, **kwargs):
+        return self._resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class RaisingSession:
+    def __init__(self, exc):
+        self._exc = exc
+
+    def post(self, url, **kwargs):
+        raise self._exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def test_normalize_mcp_url():
+    assert _normalize_mcp_url("http://127.0.0.1:8767") == "http://127.0.0.1:8767/mcp"
+    assert _normalize_mcp_url("http://127.0.0.1:8767/") == "http://127.0.0.1:8767/mcp"
+    assert _normalize_mcp_url("http://127.0.0.1:8767/mcp") == "http://127.0.0.1:8767/mcp"
+    assert _normalize_mcp_url("http://127.0.0.1:8767/mcp/") == "http://127.0.0.1:8767/mcp"
+
+
+@pytest.mark.asyncio
+async def test_search_mempalace_unconfigured():
+    res = await search_mempalace_mcp("test", endpoint="", token="")
+    assert res["status"] == "unconfigured"
+    assert "kesulitan" in res["narrative"]
+    assert res["drawers"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_mempalace_mock_success():
+    inner_text = (
+        '{"results": [{"wing": "docs", "room": "arch", "source_file": "a.md", '
+        '"similarity": 0.88, "text": "Architecture details here."}]}'
+    )
+    mock_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "content": [{"type": "text", "text": inner_text}]
+        }
+    }
+    resp = FakeResponse(200, mock_payload)
+    with patch("aiohttp.ClientSession", return_value=FakeSession(resp)):
+        res = await search_mempalace_mcp("arch", endpoint="http://fake:8767", token="dummy")
+        assert res["status"] == "ok"
+        assert len(res["drawers"]) == 1
+        assert res["drawers"][0]["wing"] == "docs"
+        assert res["drawers"][0]["room"] == "arch"
+        assert "Architecture details here." in res["drawers"][0]["text"]
+        assert "Hasil pencarian ingatan" in res["narrative"]
+
+
+@pytest.mark.asyncio
+async def test_search_mempalace_timeout_fallback():
+    with patch("aiohttp.ClientSession", return_value=RaisingSession(asyncio.TimeoutError())):
+        res = await search_mempalace_mcp("arch", endpoint="http://fake:8767", token="dummy")
+        assert res["status"] == "timeout"
+        assert "kesulitan" in res["narrative"]
+        assert res["drawers"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_mempalace_500_fail_open():
+    resp = FakeResponse(500, {}, "Internal Server Error")
+    with patch("aiohttp.ClientSession", return_value=FakeSession(resp)):
+        res = await search_mempalace_mcp("arch", endpoint="http://fake:8767", token="dummy")
+        assert res["status"] == "fail_open"
+        assert res["http_code"] == 500
+        assert "kesulitan" in res["narrative"]
+        assert res["drawers"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_mempalace_live_against_service():
+    """Live verification against local port 8767 if token is present."""
+    token = None
+    env_local = "/home/ubuntu/projects/shorekeeper/apps/agent/.env.local"
+    if os.path.exists(env_local):
+        with open(env_local) as f:
+            for line in f:
+                if line.startswith("MEMPALACE_MCP_HTTP_TOKEN="):
+                    token = line.strip().split("=", 1)[1]
+
+    if not token:
+        pytest.skip("MEMPALACE_MCP_HTTP_TOKEN not found in .env.local")
+
+    res = await search_mempalace_mcp(
+        query="shorekeeper",
+        limit=2,
+        endpoint="http://127.0.0.1:8767/mcp",
+        token=token,
+        timeout=5.0,
+    )
+    assert res["status"] == "ok"
+    assert len(res["drawers"]) > 0
+    assert res["latency_ms"] < 2000
+    assert "Hasil pencarian" in res["narrative"]

--- a/apps/agent/tests/test_sprint_a.py
+++ b/apps/agent/tests/test_sprint_a.py
@@ -5,6 +5,7 @@ Tidak ada network call nyata.
 """
 
 import asyncio
+import json
 from unittest.mock import patch
 
 import pytest
@@ -31,11 +32,14 @@ class FakeResponse:
 
 
 class FakeSession:
-    def __init__(self, response):
-        self._response = response
+    def __init__(self, resp):
+        self._resp = resp
 
     def get(self, url, **kwargs):
-        return self._response
+        return self._resp
+
+    def post(self, url, **kwargs):
+        return self._resp
 
     async def __aenter__(self):
         return self
@@ -53,6 +57,9 @@ class RaisingSession:
     def get(self, url, **kwargs):
         raise self._exc
 
+    def post(self, url, **kwargs):
+        raise self._exc
+
     async def __aenter__(self):
         return self
 
@@ -64,9 +71,10 @@ class RaisingSession:
 async def test_memory_search_success(monkeypatch):
     monkeypatch.setenv("MEMPALACE_MCP_HTTP_ENDPOINT", "http://fake:9999")
     monkeypatch.setenv("MEMPALACE_MCP_HTTP_TOKEN", "tok")
-    payload = {"results": [{"title": "ADR-002", "content": "transport decision", "wing": "decisions"}]}
+    inner_payload = {"results": [{"wing": "decisions", "room": "arch", "text": "ADR-002 transport decision", "similarity": 0.9}]}
+    payload = {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": json.dumps(inner_payload)}]}}
     resp = FakeResponse(200, payload)
-    with patch.object(agl.aiohttp, "ClientSession", return_value=FakeSession(resp)):
+    with patch("mempalace_client.aiohttp.ClientSession", return_value=FakeSession(resp)):
         out = await agl.search_mempalace("keputusan transport")
     assert "ADR-002" in out
     assert "decisions" in out
@@ -101,9 +109,10 @@ async def test_build_session_context_mempalace_success(monkeypatch, tmp_path):
     monkeypatch.setattr(agl, "DB_PATH", str(tmp_path / "tasks.db"))
     monkeypatch.setenv("MEMPALACE_MCP_HTTP_ENDPOINT", "http://fake:9999")
     monkeypatch.setenv("MEMPALACE_MCP_HTTP_TOKEN", "tok")
-    payload = {"results": [{"content": "Schnee suka ringkas"}]}
+    inner_payload = {"results": [{"wing": "prefs", "room": "style", "text": "Schnee suka ringkas", "similarity": 0.9}]}
+    payload = {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": json.dumps(inner_payload)}]}}
     resp = FakeResponse(200, payload)
-    with patch.object(agl.aiohttp, "ClientSession", return_value=FakeSession(resp)):
+    with patch("mempalace_client.aiohttp.ClientSession", return_value=FakeSession(resp)):
         out = await agl.build_session_context("room-1")
     assert "[KONTEKS SAAT INI]" in out
 


### PR DESCRIPTION
Closes #18

### Summary of Changes
- Implemented `search_mempalace_mcp` in `apps/agent/src/mempalace_client.py` targeting JSON-RPC 2.0 `tools/call` at `POST http://127.0.0.1:8767/mcp`.
- Replaced non-existent `GET /search` in `search_mempalace` and `build_session_context` in `agent_gemini_live.py`.
- Replaced obsolete tests and added live integration suite.

### Verification
- `uv run --project apps/agent ruff check .` passed.
- `uv run --project apps/agent pytest -q apps/agent/tests` passed (30/30 passed).