### PR TITLE
fix(client): pin pnpm 9.15.9 via npm to fix Docker build

### DIFF
--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -6,8 +6,8 @@ FROM node:22-alpine AS builder
 
 WORKDIR /build
 
-# Enable pnpm via corepack
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Enable pnpm with pinned stable version (9.15.9 matching lockfile)
+RUN npm install -g pnpm@9.15.9
 
 # Copy root monorepo package manifests
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
Pin pnpm to stable version 9.15.9 in apps/client/Dockerfile instead of relying on corepack dynamic binary fetch which triggered Node 22 Undici assertion errors during docker buildx.