### PR TITLE
fix(agent): fix unconfigured param evaluation in search_mempalace_mcp

### DIFF
--- a/apps/agent/src/mempalace_client.py
+++ b/apps/agent/src/mempalace_client.py
@@ -47,7 +47,9 @@ async def search_mempalace_mcp(
     Fails open gracefully: returns polite natural narrative on timeout or error,
     never crashing or leaking raw stack traces.
     """
-    mcp_endpoint = os.getenv("MEMPALACE_MCP_HTTP_ENDPOINT", "") if endpoint is None else endpoint
+    mcp_endpoint = (
+        os.getenv("MEMPALACE_MCP_HTTP_ENDPOINT", "") if endpoint is None else endpoint
+    )
     mcp_token = os.getenv("MEMPALACE_MCP_HTTP_TOKEN", "") if token is None else token
 
     if not mcp_endpoint or not mcp_token:

--- a/apps/agent/src/mempalace_client.py
+++ b/apps/agent/src/mempalace_client.py
@@ -47,8 +47,8 @@ async def search_mempalace_mcp(
     Fails open gracefully: returns polite natural narrative on timeout or error,
     never crashing or leaking raw stack traces.
     """
-    mcp_endpoint = endpoint or os.getenv("MEMPALACE_MCP_HTTP_ENDPOINT", "")
-    mcp_token = token or os.getenv("MEMPALACE_MCP_HTTP_TOKEN", "")
+    mcp_endpoint = os.getenv("MEMPALACE_MCP_HTTP_ENDPOINT", "") if endpoint is None else endpoint
+    mcp_token = os.getenv("MEMPALACE_MCP_HTTP_TOKEN", "") if token is None else token
 
     if not mcp_endpoint or not mcp_token:
         return {


### PR DESCRIPTION
Handle empty string overrides properly in search_mempalace_mcp so explicit endpoint='' and token='' are treated as unconfigured rather than falling back to env vars. All 30 pytest cases now pass.