### PR TITLE
fix(ci): point pytest directly to tests folder in apps/agent

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run Python Agent Tests
         run: |
           cd apps/agent
-          uv run pytest -v apps/agent/tests || uv run pytest -v tests
+          uv run pytest -v tests
 
   build-and-push:
     name: Build & Push GHCR Containers


### PR DESCRIPTION
Point pytest directly to tests directory inside apps/agent rather than fallback string to ensure clean deterministic test discovery in CI.